### PR TITLE
Update api url

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -10,7 +10,7 @@ module.exports = function(environment) {
       'default-src': "'none'",
       'script-src': "'self' 'unsafe-eval' 'unsafe-inline' *.googleapis.com *.gstatic.com *maps.google.com/maps-api-v3/api/*",
       'font-src': "'self' *.gstatic.com ",
-      'connect-src': "'self' https://atlanta-ember-backend-app.herokuapp.com http://localhost:3000",
+      'connect-src': "'self' https://atlanta-ember-api-legacy.herokuapp.com/ http://localhost:3000",
       'img-src': "'self' data: *.googleapis.com *.gstatic.com 'http://photos2.meetupstatic.com/photos' http://photos2.meetupstatic.com",
       'style-src': "'self' 'unsafe-inline' *.googleapis.com",
       'media-src': "'self'"
@@ -54,7 +54,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-    ENV.domain = 'https://atlanta-ember-backend-app.herokuapp.com';
+    ENV.domain = 'https://atlanta-ember-api-legacy.herokuapp.com/';
   }
 
   return ENV;


### PR DESCRIPTION
updates the API url to `atlanta-ember-api-legacy` which is on @ultimatemonty's Heroku account. This enables us to update to a Hobby dyno and reduce load time on atlantaember.io while waiting on the API to spin up.