### PR TITLE
Use old URL until we figure out WTF is up with new URL

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -10,7 +10,7 @@ module.exports = function(environment) {
       'default-src': "'none'",
       'script-src': "'self' 'unsafe-eval' 'unsafe-inline' *.googleapis.com *.gstatic.com *maps.google.com/maps-api-v3/api/*",
       'font-src': "'self' *.gstatic.com ",
-      'connect-src': "'self' https://atlanta-ember-api-legacy.herokuapp.com/ http://localhost:3000",
+      'connect-src': "'self' https://atlanta-ember-backend-app.herokuapp.com http://localhost:3000",
       'img-src': "'self' data: *.googleapis.com *.gstatic.com 'http://photos2.meetupstatic.com/photos' http://photos2.meetupstatic.com",
       'style-src': "'self' 'unsafe-inline' *.googleapis.com",
       'media-src': "'self'"
@@ -54,7 +54,7 @@ module.exports = function(environment) {
   }
 
   if (environment === 'production') {
-    ENV.domain = 'https://atlanta-ember-api-legacy.herokuapp.com';
+    ENV.domain = 'https://atlanta-ember-backend-app.herokuapp.com';
   }
 
   return ENV;


### PR DESCRIPTION
new API throwing a 500. My limited Rails knowledge says a revert is a good idea.